### PR TITLE
Implement loose option

### DIFF
--- a/e2e/fixture-package-mangled-babel-esm/index.d.ts
+++ b/e2e/fixture-package-mangled-babel-esm/index.d.ts
@@ -1,0 +1,7 @@
+export default function square(x: number): number;
+export const version: string;
+
+export let counter: number;
+export function countUp(): void;
+
+export function getThis<T>(this: T): T;

--- a/e2e/fixture-package-mangled-babel-esm/index.js
+++ b/e2e/fixture-package-mangled-babel-esm/index.js
@@ -1,0 +1,45 @@
+"use strict";
+
+function __define(obj, name, value) {
+  Object.defineProperty(obj, name, {
+    value: value
+  });
+}
+
+__define(exports, "__esModule", true);
+exports.countUp = countUp;
+exports.counter = void 0;
+exports.default = square;
+exports.getThis = getThis;
+exports.version = void 0;
+
+function square(x) {
+  return x * x;
+}
+
+const version = "0.1.2";
+exports.version = version;
+let counter = 0;
+exports.counter = counter;
+
+function countUp() {
+  exports.counter = counter = counter + 1;
+}
+
+function getThis() {
+  return this;
+}
+
+// export default function square(x) {
+//   return x * x;
+// }
+// export const version = "0.1.2";
+//
+// export let counter = 0;
+// export function countUp() {
+//   counter++;
+// }
+//
+// export function getThis() {
+//   return this;
+// }

--- a/e2e/fixture-package-mangled-babel-esm/package.json
+++ b/e2e/fixture-package-mangled-babel-esm/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "fixture-package-mangled-babel-esm",
+  "main": "./index.js",
+  "types": "./index.d.ts"
+}

--- a/e2e/tests-e2e/package.json
+++ b/e2e/tests-e2e/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "babel-plugin-node-cjs-interop": "workspace:*",
     "fixture-package-babel-esm": "workspace:*",
+    "fixture-package-mangled-babel-esm": "workspace:*",
     "fixture-package-native-esm": "workspace:*",
     "fixture-package-pure-cjs": "workspace:*",
     "node-cjs-interop": "workspace:*",

--- a/e2e/tests-e2e/src/basic/.babelrc.js
+++ b/e2e/tests-e2e/src/basic/.babelrc.js
@@ -3,7 +3,7 @@ export default {
     [
       "babel-plugin-node-cjs-interop",
       {
-        packages: ["fixture-package-babel-esm"],
+        packages: ["fixture-package-babel-esm", "fixture-package-mangled-babel-esm"],
       },
     ],
   ],

--- a/e2e/tests-e2e/src/basic/.babelrc.js
+++ b/e2e/tests-e2e/src/basic/.babelrc.js
@@ -3,7 +3,10 @@ export default {
     [
       "babel-plugin-node-cjs-interop",
       {
-        packages: ["fixture-package-babel-esm", "fixture-package-mangled-babel-esm"],
+        packages: [
+          "fixture-package-babel-esm",
+          "fixture-package-mangled-babel-esm",
+        ],
       },
     ],
   ],

--- a/e2e/tests-e2e/src/basic/.swcrc
+++ b/e2e/tests-e2e/src/basic/.swcrc
@@ -6,7 +6,7 @@
     "experimental": {
       "plugins": [
         ["swc-plugin-node-cjs-interop", {
-          "packages": ["fixture-package-babel-esm"]
+          "packages": ["fixture-package-babel-esm", "fixture-package-mangled-babel-esm"]
         }]
       ]
     }

--- a/e2e/tests-e2e/src/basic/by-name.test.ts
+++ b/e2e/tests-e2e/src/basic/by-name.test.ts
@@ -17,6 +17,12 @@ import square3, {
   countUp as countUp3,
   getThis as getThis3,
 } from "fixture-package-pure-cjs";
+import square4, {
+  version as version4,
+  counter as counter4,
+  countUp as countUp4,
+  getThis as getThis4,
+} from "fixture-package-mangled-babel-esm";
 
 describe("Basic usage with named imports", () => {
   describe("Native ESM", () => {
@@ -67,4 +73,23 @@ describe("Basic usage with named imports", () => {
       expect(getThis3()).toBe(undefined);
     });
   });
+  describe("Mangled Babel ESM", () => {
+    it("imports namespace as default", () => {
+      expect((square4 as Interop<typeof square4>).default(10)).toBe(100);
+      expect(typeof square4).toBe("object");
+    });
+    it("imports named exports correctly", () => {
+      expect(version4).toBe("0.1.2");
+    });
+    it("references the initial value", () => {
+      const oldValue = counter4;
+      countUp4();
+      expect(counter4).toBe(oldValue);
+    });
+    it("doesn't attach the module as this value", () => {
+      expect(getThis4()).toBe(undefined);
+    });
+  });
 });
+
+type Interop<T> = T & { default: T };

--- a/e2e/tests-e2e/src/basic/by-namespace.test.ts
+++ b/e2e/tests-e2e/src/basic/by-namespace.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import * as ns1 from "fixture-package-native-esm";
 import * as ns2 from "fixture-package-babel-esm";
 import * as ns3 from "fixture-package-pure-cjs";
+import * as ns4 from "fixture-package-mangled-babel-esm";
 
 describe("Basic usage with namespace imports", () => {
   describe("Native ESM", () => {
@@ -50,6 +51,23 @@ describe("Basic usage with namespace imports", () => {
     });
     it("is not callable by itself", () => {
       expect(typeof ns3).toBe("object");
+    });
+  });
+  describe("Mangled Babel ESM", () => {
+    it("imports namespace as default", () => {
+      expect((ns4 as Interop<typeof ns4>).default.default(10)).toBe(100);
+      expect(typeof ns4.default).toBe("object");
+    });
+    it("imports named exports correctly", () => {
+      expect(ns4.version).toBe("0.1.2");
+    });
+    it("references the initial value", () => {
+      const oldValue = ns4.counter;
+      ns4.countUp();
+      expect(ns4.counter).toBe(oldValue);
+    });
+    it("is not callable by itself", () => {
+      expect(typeof ns4).toBe("object");
     });
   });
 });

--- a/e2e/tests-e2e/src/from-cjs/by-name.test.cts
+++ b/e2e/tests-e2e/src/from-cjs/by-name.test.cts
@@ -17,6 +17,12 @@ import square3, {
   countUp as countUp3,
   getThis as getThis3,
 } from "fixture-package-pure-cjs";
+import square4, {
+  version as version4,
+  counter as counter4,
+  countUp as countUp4,
+  getThis as getThis4,
+} from "fixture-package-mangled-babel-esm";
 
 describe("Basic CJS usage with named imports", () => {
   describe("Native ESM", () => {
@@ -65,6 +71,22 @@ describe("Basic CJS usage with named imports", () => {
     });
     it("doesn't attach the module as this value", () => {
       expect(getThis3()).toBe(undefined);
+    });
+  });
+  describe("Mangled Babel ESM", () => {
+    it("imports default exports correctly", () => {
+      expect(square4(10)).toBe(100);
+    });
+    it("imports named exports correctly", () => {
+      expect(version4).toBe("0.1.2");
+    });
+    it("references the up-to-date value", () => {
+      const oldValue = counter4;
+      countUp4();
+      expect(counter4).toBe(oldValue + 1);
+    });
+    it("doesn't attach the module as this value", () => {
+      expect(getThis4()).toBe(undefined);
     });
   });
 });

--- a/e2e/tests-e2e/src/from-cjs/by-namespace.test.cts
+++ b/e2e/tests-e2e/src/from-cjs/by-namespace.test.cts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import * as ns1 from "fixture-package-native-esm";
 import * as ns2 from "fixture-package-babel-esm";
 import * as ns3 from "fixture-package-pure-cjs";
+import * as ns4 from "fixture-package-mangled-babel-esm";
 
 describe("Basic CJS usage with namespace imports", () => {
   describe("Native ESM", () => {
@@ -50,6 +51,22 @@ describe("Basic CJS usage with namespace imports", () => {
     });
     it("is not callable by itself", () => {
       expect(typeof ns3).toBe("object");
+    });
+  });
+  describe("Mangled Babel ESM", () => {
+    it("imports default exports correctly", () => {
+      expect(ns4.default(10)).toBe(100);
+    });
+    it("imports named exports correctly", () => {
+      expect(ns4.version).toBe("0.1.2");
+    });
+    it("references the up-to-date value", () => {
+      const oldValue = ns4.counter;
+      ns4.countUp();
+      expect(ns4.counter).toBe(oldValue + 1);
+    });
+    it("is not callable by itself", () => {
+      expect(typeof ns4).toBe("object");
     });
   });
 });

--- a/e2e/tests-e2e/src/loose/.babelrc.js
+++ b/e2e/tests-e2e/src/loose/.babelrc.js
@@ -3,7 +3,10 @@ export default {
     [
       "babel-plugin-node-cjs-interop",
       {
-        packages: ["fixture-package-babel-esm", "fixture-package-mangled-babel-esm"],
+        packages: [
+          "fixture-package-babel-esm",
+          "fixture-package-mangled-babel-esm",
+        ],
         loose: true,
       },
     ],

--- a/e2e/tests-e2e/src/loose/.babelrc.js
+++ b/e2e/tests-e2e/src/loose/.babelrc.js
@@ -1,0 +1,11 @@
+export default {
+  plugins: [
+    [
+      "babel-plugin-node-cjs-interop",
+      {
+        packages: ["fixture-package-babel-esm", "fixture-package-mangled-babel-esm"],
+        loose: true,
+      },
+    ],
+  ],
+};

--- a/e2e/tests-e2e/src/loose/.swcrc
+++ b/e2e/tests-e2e/src/loose/.swcrc
@@ -6,7 +6,8 @@
     "experimental": {
       "plugins": [
         ["swc-plugin-node-cjs-interop", {
-          "packages": ["fixture-package-babel-esm"]
+          "packages": ["fixture-package-babel-esm", "fixture-package-mangled-babel-esm"],
+          "loose": true
         }]
       ]
     }

--- a/e2e/tests-e2e/src/loose/.swcrc
+++ b/e2e/tests-e2e/src/loose/.swcrc
@@ -1,0 +1,14 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript"
+    },
+    "experimental": {
+      "plugins": [
+        ["swc-plugin-node-cjs-interop", {
+          "packages": ["fixture-package-babel-esm"]
+        }]
+      ]
+    }
+  }
+}

--- a/e2e/tests-e2e/src/loose/by-name.test.ts
+++ b/e2e/tests-e2e/src/loose/by-name.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "@jest/globals";
+import square1, {
+  version as version1,
+  counter as counter1,
+  countUp as countUp1,
+  getThis as getThis1,
+} from "fixture-package-native-esm";
+import square2, {
+  version as version2,
+  counter as counter2,
+  countUp as countUp2,
+  getThis as getThis2,
+} from "fixture-package-babel-esm";
+import square3, {
+  version as version3,
+  counter as counter3,
+  countUp as countUp3,
+  getThis as getThis3,
+} from "fixture-package-pure-cjs";
+import square4, {
+  version as version4,
+  counter as counter4,
+  countUp as countUp4,
+  getThis as getThis4,
+} from "fixture-package-mangled-babel-esm";
+
+describe("Basic usage with named imports", () => {
+  describe("Native ESM", () => {
+    it("imports default exports correctly", () => {
+      expect(square1(10)).toBe(100);
+    });
+    it("imports named exports correctly", () => {
+      expect(version1).toBe("0.1.2");
+    });
+    it("references the up-to-date value", () => {
+      const oldValue = counter1;
+      countUp1();
+      expect(counter1).toBe(oldValue + 1);
+    });
+    it("doesn't attach the module as this value", () => {
+      expect(getThis1()).toBe(undefined);
+    });
+  });
+  describe("Babel ESM", () => {
+    it("imports default exports correctly", () => {
+      expect(square2(10)).toBe(100);
+    });
+    it("imports named exports correctly", () => {
+      expect(version2).toBe("0.1.2");
+    });
+    it("references the up-to-date value", () => {
+      const oldValue = counter2;
+      countUp2();
+      expect(counter2).toBe(oldValue + 1);
+    });
+    it("doesn't attach the module as this value", () => {
+      expect(getThis2()).toBe(undefined);
+    });
+  });
+  describe("Pure CJS", () => {
+    it("imports default exports correctly", () => {
+      expect(square3(10)).toBe(100);
+    });
+    it("imports named exports correctly", () => {
+      expect(version3).toBe("0.1.2");
+    });
+    it("references the initial value", () => {
+      const oldValue = counter3;
+      countUp3();
+      expect(counter3).toBe(oldValue);
+    });
+    it("doesn't attach the module as this value", () => {
+      expect(getThis3()).toBe(undefined);
+    });
+  });
+  describe("Mangled Babel ESM", () => {
+    it("imports default exports correctly", () => {
+      expect(square4(10)).toBe(100);
+    });
+    it("imports named exports correctly", () => {
+      expect(version4).toBe("0.1.2");
+    });
+    it("references the up-to-date value", () => {
+      const oldValue = counter4;
+      countUp4();
+      expect(counter4).toBe(oldValue + 1);
+    });
+    it("doesn't attach the module as this value", () => {
+      expect(getThis4()).toBe(undefined);
+    });
+  });
+});

--- a/e2e/tests-e2e/src/loose/by-name.test.ts
+++ b/e2e/tests-e2e/src/loose/by-name.test.ts
@@ -24,7 +24,7 @@ import square4, {
   getThis as getThis4,
 } from "fixture-package-mangled-babel-esm";
 
-describe("Basic usage with named imports", () => {
+describe("Basic usage (+loose) with named imports", () => {
   describe("Native ESM", () => {
     it("imports default exports correctly", () => {
       expect(square1(10)).toBe(100);

--- a/e2e/tests-e2e/src/loose/by-namespace.test.ts
+++ b/e2e/tests-e2e/src/loose/by-namespace.test.ts
@@ -4,7 +4,7 @@ import * as ns2 from "fixture-package-babel-esm";
 import * as ns3 from "fixture-package-pure-cjs";
 import * as ns4 from "fixture-package-mangled-babel-esm";
 
-describe("Basic usage with namespace imports", () => {
+describe("Basic usage (+loose) with namespace imports", () => {
   describe("Native ESM", () => {
     it("imports default exports correctly", () => {
       expect(ns1.default(10)).toBe(100);

--- a/e2e/tests-e2e/src/loose/by-namespace.test.ts
+++ b/e2e/tests-e2e/src/loose/by-namespace.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "@jest/globals";
+import * as ns1 from "fixture-package-native-esm";
+import * as ns2 from "fixture-package-babel-esm";
+import * as ns3 from "fixture-package-pure-cjs";
+import * as ns4 from "fixture-package-mangled-babel-esm";
+
+describe("Basic usage with namespace imports", () => {
+  describe("Native ESM", () => {
+    it("imports default exports correctly", () => {
+      expect(ns1.default(10)).toBe(100);
+    });
+    it("imports named exports correctly", () => {
+      expect(ns1.version).toBe("0.1.2");
+    });
+    it("references the up-to-date value", () => {
+      const oldValue = ns1.counter;
+      ns1.countUp();
+      expect(ns1.counter).toBe(oldValue + 1);
+    });
+    it("is not callable by itself", () => {
+      expect(typeof ns1).toBe("object");
+    });
+  });
+  describe("Babel ESM", () => {
+    it("imports default exports correctly", () => {
+      expect(ns2.default(10)).toBe(100);
+    });
+    it("imports named exports correctly", () => {
+      expect(ns2.version).toBe("0.1.2");
+    });
+    it("references the up-to-date value", () => {
+      const oldValue = ns2.counter;
+      ns2.countUp();
+      expect(ns2.counter).toBe(oldValue + 1);
+    });
+    it("is not callable by itself", () => {
+      expect(typeof ns2).toBe("object");
+    });
+  });
+  describe("Pure CJS", () => {
+    it("imports default exports correctly", () => {
+      expect((ns3 as Interop<typeof ns3>).default(10)).toBe(100);
+    });
+    it("imports named exports correctly", () => {
+      expect(ns3.version).toBe("0.1.2");
+    });
+    it("references the initial value", () => {
+      const oldValue = ns3.counter;
+      ns3.countUp();
+      expect(ns3.counter).toBe(oldValue);
+    });
+    it("is not callable by itself", () => {
+      expect(typeof ns3).toBe("object");
+    });
+  });
+  describe("Mangled Babel ESM", () => {
+    it("imports default exports correctly", () => {
+      expect(ns4.default(10)).toBe(100);
+    });
+    it("imports named exports correctly", () => {
+      expect(ns4.version).toBe("0.1.2");
+    });
+    it("references the up-to-date value", () => {
+      const oldValue = ns4.counter;
+      ns4.countUp();
+      expect(ns4.counter).toBe(oldValue + 1);
+    });
+    it("is not callable by itself", () => {
+      expect(typeof ns4).toBe("object");
+    });
+  });
+});
+
+type Interop<T> = T & { default: T };

--- a/e2e/tests-e2e/src/no-transform/by-name.test.ts
+++ b/e2e/tests-e2e/src/no-transform/by-name.test.ts
@@ -17,6 +17,12 @@ import square3, {
   countUp as countUp3,
   getThis as getThis3,
 } from "fixture-package-pure-cjs";
+import square4, {
+  version as version4,
+  counter as counter4,
+  countUp as countUp4,
+  getThis as getThis4,
+} from "fixture-package-mangled-babel-esm";
 
 describe("No transform with named imports", () => {
   describe("Native ESM", () => {
@@ -66,6 +72,23 @@ describe("No transform with named imports", () => {
     });
     it("doesn't attach the module as this value", () => {
       expect(getThis3()).toBe(undefined);
+    });
+  });
+  describe("Mangled Babel ESM", () => {
+    it("imports namespace as default", () => {
+      expect((square4 as Interop<typeof square4>).default(10)).toBe(100);
+      expect(typeof square4).toBe("object");
+    });
+    it("imports named exports correctly", () => {
+      expect(version4).toBe("0.1.2");
+    });
+    it("references the initial value", () => {
+      const oldValue = counter4;
+      countUp4();
+      expect(counter4).toBe(oldValue);
+    });
+    it("doesn't attach the module as this value", () => {
+      expect(getThis4()).toBe(undefined);
     });
   });
 });

--- a/e2e/tests-e2e/src/no-transform/by-namespace.test.ts
+++ b/e2e/tests-e2e/src/no-transform/by-namespace.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import * as ns1 from "fixture-package-native-esm";
 import * as ns2 from "fixture-package-babel-esm";
 import * as ns3 from "fixture-package-pure-cjs";
+import * as ns4 from "fixture-package-mangled-babel-esm";
 
 describe("No transform with namespace imports", () => {
   describe("Native ESM", () => {
@@ -22,7 +23,7 @@ describe("No transform with namespace imports", () => {
   });
   describe("Babel ESM", () => {
     it("imports namespace as default", () => {
-      expect((ns2 as Interop<typeof ns3>).default.default(10)).toBe(100);
+      expect((ns2 as Interop<typeof ns2>).default.default(10)).toBe(100);
       expect(typeof ns2.default).toBe("object");
     });
     it("imports named exports correctly", () => {
@@ -51,6 +52,23 @@ describe("No transform with namespace imports", () => {
     });
     it("is not callable by itself", () => {
       expect(typeof ns3).toBe("object");
+    });
+  });
+  describe("Mangled Babel ESM", () => {
+    it("imports namespace as default", () => {
+      expect((ns4 as Interop<typeof ns4>).default.default(10)).toBe(100);
+      expect(typeof ns4.default).toBe("object");
+    });
+    it("imports named exports correctly", () => {
+      expect(ns4.version).toBe("0.1.2");
+    });
+    it("references the initial value", () => {
+      const oldValue = ns4.counter;
+      ns4.countUp();
+      expect(ns4.counter).toBe(oldValue);
+    });
+    it("is not callable by itself", () => {
+      expect(typeof ns4).toBe("object");
     });
   });
 });

--- a/e2e/tests-e2e/src/transform-all/.babelrc.js
+++ b/e2e/tests-e2e/src/transform-all/.babelrc.js
@@ -7,6 +7,7 @@ export default {
           "fixture-package-native-esm",
           "fixture-package-babel-esm",
           "fixture-package-pure-cjs",
+          "fixture-package-mangled-babel-esm",
         ],
       },
     ],

--- a/e2e/tests-e2e/src/transform-all/.swcrc
+++ b/e2e/tests-e2e/src/transform-all/.swcrc
@@ -9,7 +9,8 @@
           "packages": [
             "fixture-package-native-esm",
             "fixture-package-babel-esm",
-            "fixture-package-pure-cjs"
+            "fixture-package-pure-cjs",
+            "fixture-package-mangled-babel-esm"
           ]
         }]
       ]

--- a/e2e/tests-e2e/src/transform-all/by-name.test.ts
+++ b/e2e/tests-e2e/src/transform-all/by-name.test.ts
@@ -17,6 +17,12 @@ import square3, {
   countUp as countUp3,
   getThis as getThis3,
 } from "fixture-package-pure-cjs";
+import square4, {
+  version as version4,
+  counter as counter4,
+  countUp as countUp4,
+  getThis as getThis4,
+} from "fixture-package-mangled-babel-esm";
 
 describe("Transform all with named imports", () => {
   describe("Native ESM", () => {
@@ -67,4 +73,23 @@ describe("Transform all with named imports", () => {
       expect(getThis3()).toBe(undefined);
     });
   });
+  describe("Mangled Babel ESM", () => {
+    it("imports namespace as default", () => {
+      expect((square4 as Interop<typeof square4>).default(10)).toBe(100);
+      expect(typeof square4).toBe("object");
+    });
+    it("imports named exports correctly", () => {
+      expect(version4).toBe("0.1.2");
+    });
+    it("references the initial value", () => {
+      const oldValue = counter4;
+      countUp4();
+      expect(counter4).toBe(oldValue);
+    });
+    it("doesn't attach the module as this value", () => {
+      expect(getThis4()).toBe(undefined);
+    });
+  });
 });
+
+type Interop<T> = T & { default: T };

--- a/e2e/tests-e2e/src/transform-all/by-namespace.test.ts
+++ b/e2e/tests-e2e/src/transform-all/by-namespace.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import * as ns1 from "fixture-package-native-esm";
 import * as ns2 from "fixture-package-babel-esm";
 import * as ns3 from "fixture-package-pure-cjs";
+import * as ns4 from "fixture-package-mangled-babel-esm";
 
 describe("Transform all with namespace imports", () => {
   describe("Native ESM", () => {
@@ -50,6 +51,23 @@ describe("Transform all with namespace imports", () => {
     });
     it("is not callable by itself", () => {
       expect(typeof ns3).toBe("object");
+    });
+  });
+  describe("Mangled Babel ESM", () => {
+    it("imports namespace as default", () => {
+      expect((ns4 as Interop<typeof ns4>).default.default(10)).toBe(100);
+      expect(typeof ns4.default).toBe("object");
+    });
+    it("imports named exports correctly", () => {
+      expect(ns4.version).toBe("0.1.2");
+    });
+    it("references the initial value", () => {
+      const oldValue = ns4.counter;
+      ns4.countUp();
+      expect(ns4.counter).toBe(oldValue);
+    });
+    it("is not callable by itself", () => {
+      expect(typeof ns4).toBe("object");
     });
   });
 });

--- a/e2e/tests-e2e/src/use-runtime/.babelrc.js
+++ b/e2e/tests-e2e/src/use-runtime/.babelrc.js
@@ -3,7 +3,7 @@ export default {
     [
       "babel-plugin-node-cjs-interop",
       {
-        packages: ["fixture-package-babel-esm"],
+        packages: ["fixture-package-babel-esm", "fixture-package-mangled-babel-esm"],
         useRuntime: true,
       },
     ],

--- a/e2e/tests-e2e/src/use-runtime/.babelrc.js
+++ b/e2e/tests-e2e/src/use-runtime/.babelrc.js
@@ -3,7 +3,10 @@ export default {
     [
       "babel-plugin-node-cjs-interop",
       {
-        packages: ["fixture-package-babel-esm", "fixture-package-mangled-babel-esm"],
+        packages: [
+          "fixture-package-babel-esm",
+          "fixture-package-mangled-babel-esm",
+        ],
         useRuntime: true,
       },
     ],

--- a/e2e/tests-e2e/src/use-runtime/.swcrc
+++ b/e2e/tests-e2e/src/use-runtime/.swcrc
@@ -6,7 +6,7 @@
     "experimental": {
       "plugins": [
         ["swc-plugin-node-cjs-interop", {
-          "packages": ["fixture-package-babel-esm"],
+          "packages": ["fixture-package-babel-esm", "fixture-package-mangled-babel-esm"],
           "useRuntime": true
         }]
       ]

--- a/e2e/tests-e2e/src/use-runtime/by-name.test.ts
+++ b/e2e/tests-e2e/src/use-runtime/by-name.test.ts
@@ -17,6 +17,12 @@ import square3, {
   countUp as countUp3,
   getThis as getThis3,
 } from "fixture-package-pure-cjs";
+import square4, {
+  version as version4,
+  counter as counter4,
+  countUp as countUp4,
+  getThis as getThis4,
+} from "fixture-package-mangled-babel-esm";
 
 describe("Basic usage with named imports", () => {
   describe("Native ESM", () => {
@@ -67,4 +73,23 @@ describe("Basic usage with named imports", () => {
       expect(getThis3()).toBe(undefined);
     });
   });
+  describe("Mangled Babel ESM", () => {
+    it("imports namespace as default", () => {
+      expect((square4 as Interop<typeof square4>).default(10)).toBe(100);
+      expect(typeof square4).toBe("object");
+    });
+    it("imports named exports correctly", () => {
+      expect(version4).toBe("0.1.2");
+    });
+    it("references the initial value", () => {
+      const oldValue = counter4;
+      countUp4();
+      expect(counter4).toBe(oldValue);
+    });
+    it("doesn't attach the module as this value", () => {
+      expect(getThis4()).toBe(undefined);
+    });
+  });
 });
+
+type Interop<T> = T & { default: T };

--- a/e2e/tests-e2e/src/use-runtime/by-namespace.test.ts
+++ b/e2e/tests-e2e/src/use-runtime/by-namespace.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import * as ns1 from "fixture-package-native-esm";
 import * as ns2 from "fixture-package-babel-esm";
 import * as ns3 from "fixture-package-pure-cjs";
+import * as ns4 from "fixture-package-mangled-babel-esm";
 
 describe("Basic usage with namespace imports", () => {
   describe("Native ESM", () => {
@@ -50,6 +51,23 @@ describe("Basic usage with namespace imports", () => {
     });
     it("is not callable by itself", () => {
       expect(typeof ns3).toBe("object");
+    });
+  });
+  describe("Mangled Babel ESM", () => {
+    it("imports namespace as default", () => {
+      expect((ns4 as Interop<typeof ns4>).default.default(10)).toBe(100);
+      expect(typeof ns4.default).toBe("object");
+    });
+    it("imports named exports correctly", () => {
+      expect(ns4.version).toBe("0.1.2");
+    });
+    it("references the initial value", () => {
+      const oldValue = ns4.counter;
+      ns4.countUp();
+      expect(ns4.counter).toBe(oldValue);
+    });
+    it("is not callable by itself", () => {
+      expect(typeof ns4).toBe("object");
     });
   });
 });

--- a/packages/babel-plugin-node-cjs-interop/CHANGELOG.md
+++ b/packages/babel-plugin-node-cjs-interop/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+Add `loose` option to support more libraries.
+
 ## 0.1.1
 
 Fix `Property typeName of TSTypeReference expected node to be of a type ["TSEntityName"] but instead got "MemberExpression"` when used in conjunction with TypeScript

--- a/packages/babel-plugin-node-cjs-interop/README.md
+++ b/packages/babel-plugin-node-cjs-interop/README.md
@@ -193,6 +193,17 @@ You can use [`node-cjs-interop-finder`](https://npmjs.com/package/node-cjs-inter
 npx node-cjs-interop-finder
 ```
 
+### loose
+
+- type: `boolean`
+- default: `false`
+
+Skips check of the `ns.__esModule` export. Note that it still checks
+for `ns.default.__esModule`.
+
+This is useful if a transpiler or a bundler generates a module
+which cjs-module-lexer cannot correctly parse.
+
 ### useRuntime
 
 - type: `boolean`

--- a/packages/babel-plugin-node-cjs-interop/src/index.ts
+++ b/packages/babel-plugin-node-cjs-interop/src/index.ts
@@ -96,10 +96,7 @@ export default declare<Options, Babel.PluginObj>((api, options) => {
               nsImport,
               t.callExpression(t.cloneNode(importHelper), [
                 t.cloneNode(importOriginalName),
-                ...(options.loose ?
-                  [t.booleanLiteral(true)] :
-                  []
-                ),
+                ...(options.loose ? [t.booleanLiteral(true)] : []),
               ])
             ),
           ])
@@ -226,7 +223,10 @@ function getImportHelper(
                 t.logicalExpression(
                   "||",
                   t.cloneNode(loose),
-                  t.memberExpression(t.cloneNode(ns), t.identifier("__esModule")),
+                  t.memberExpression(
+                    t.cloneNode(ns),
+                    t.identifier("__esModule")
+                  )
                 ),
                 t.cloneNode(nsDefault)
               ),

--- a/packages/babel-plugin-node-cjs-interop/src/options.test.ts
+++ b/packages/babel-plugin-node-cjs-interop/src/options.test.ts
@@ -10,7 +10,7 @@ describe("validateOptions", () => {
   it("forbids unknown option keys", () => {
     const options = { foo: 42 };
     expect(() => validateOptions(options)).toThrow(
-      "babel-plugin-node-cjs-interop: 'foo' is not a valid top-level option.\n- Did you mean 'packages'?"
+      "babel-plugin-node-cjs-interop: 'foo' is not a valid top-level option.\n- Did you mean 'loose'?"
     );
   });
 
@@ -35,6 +35,23 @@ describe("validateOptions", () => {
     const options = { packages: ["foo/bar", "foo"] };
     expect(() => validateOptions(options)).toThrow(
       "babel-plugin-node-cjs-interop: not a package name: foo/bar"
+    );
+  });
+
+  it("allows loose as false", () => {
+    const options = { loose: false };
+    expect(() => validateOptions(options)).not.toThrow();
+  });
+
+  it("allows loose as true", () => {
+    const options = { loose: true };
+    expect(() => validateOptions(options)).not.toThrow();
+  });
+
+  it("forbids invalid loose value", () => {
+    const options = { loose: 10 };
+    expect(() => validateOptions(options)).toThrow(
+      "babel-plugin-node-cjs-interop: 'loose' option must be a boolean."
     );
   });
 

--- a/packages/babel-plugin-node-cjs-interop/src/options.ts
+++ b/packages/babel-plugin-node-cjs-interop/src/options.ts
@@ -18,10 +18,7 @@ const optionShape = {
 export function validateOptions(options: object): asserts options is Options {
   v.validateTopLevelOptions(options, optionShape);
   validatePackages(options.packages);
-  v.validateBooleanOption(
-    "loose",
-    options.loose as boolean | undefined
-  );
+  v.validateBooleanOption("loose", options.loose as boolean | undefined);
   v.validateBooleanOption(
     "useRuntime",
     options.useRuntime as boolean | undefined

--- a/packages/babel-plugin-node-cjs-interop/src/options.ts
+++ b/packages/babel-plugin-node-cjs-interop/src/options.ts
@@ -5,17 +5,23 @@ const v: OptionValidator = new OptionValidator("babel-plugin-node-cjs-interop");
 
 export type Options = {
   packages?: string[] | undefined;
+  loose?: boolean;
   useRuntime?: boolean;
 };
 
 const optionShape = {
   packages: "string[]",
+  loose: "boolean",
   useRuntime: "boolean",
 } as const;
 
 export function validateOptions(options: object): asserts options is Options {
   v.validateTopLevelOptions(options, optionShape);
   validatePackages(options.packages);
+  v.validateBooleanOption(
+    "loose",
+    options.loose as boolean | undefined
+  );
   v.validateBooleanOption(
     "useRuntime",
     options.useRuntime as boolean | undefined

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/call-replacement/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/call-replacement/output.mjs
@@ -1,7 +1,7 @@
 const _ns = _interopImportCJSNamespace(_nsOrig);
 
-function _interopImportCJSNamespace(ns) {
-  return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 
 /*#__CJS__*/

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/default-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/default-imports/output.mjs
@@ -1,7 +1,7 @@
 const _ns = _interopImportCJSNamespace(_nsOrig);
 
-function _interopImportCJSNamespace(ns) {
-  return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 
 /*#__CJS__*/

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/multiple-import-decls/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/multiple-import-decls/output.mjs
@@ -8,8 +8,8 @@ const _ns2 = _interopImportCJSNamespace(_nsOrig2);
 
 const _ns = _interopImportCJSNamespace(_nsOrig);
 
-function _interopImportCJSNamespace(ns) {
-  return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 
 /*#__CJS__*/

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/multiple-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/multiple-imports/output.mjs
@@ -1,7 +1,7 @@
 const _ns = _interopImportCJSNamespace(_nsOrig);
 
-function _interopImportCJSNamespace(ns) {
-  return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 
 /*#__CJS__*/

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/named-default-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/named-default-imports/output.mjs
@@ -1,7 +1,7 @@
 const _ns = _interopImportCJSNamespace(_nsOrig);
 
-function _interopImportCJSNamespace(ns) {
-  return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 
 /*#__CJS__*/

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/named-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/named-imports/output.mjs
@@ -1,7 +1,7 @@
 const _ns = _interopImportCJSNamespace(_nsOrig);
 
-function _interopImportCJSNamespace(ns) {
-  return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 
 /*#__CJS__*/

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/namespace-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/namespace-imports/output.mjs
@@ -1,7 +1,7 @@
 const M = _interopImportCJSNamespace(_nsOrig);
 
-function _interopImportCJSNamespace(ns) {
-  return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 
 /*#__CJS__*/

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/todo-forbidden-rewriting/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/basic/todo-forbidden-rewriting/output.mjs
@@ -1,7 +1,7 @@
 const _ns = _interopImportCJSNamespace(_nsOrig);
 
-function _interopImportCJSNamespace(ns) {
-  return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 
 /*#__CJS__*/

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/braces-only-imports/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/braces-only-imports/input.mjs
@@ -1,0 +1,1 @@
+import {} from "mod";

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/braces-only-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/braces-only-imports/output.mjs
@@ -1,0 +1,1 @@
+import "mod";

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/call-replacement/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/call-replacement/input.mjs
@@ -1,0 +1,6 @@
+import { f } from "mod";
+
+console.log(f());
+console.log(f.g());
+console.log(f?.());
+console.log(f`foo`);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/call-replacement/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/call-replacement/output.mjs
@@ -1,0 +1,12 @@
+const _ns = _interopImportCJSNamespace(_nsOrig, true);
+
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+
+/*#__CJS__*/
+import * as _nsOrig from "mod";
+console.log((0, _ns.f)());
+console.log(_ns.f.g());
+console.log((0, _ns.f)?.());
+console.log((0, _ns.f)`foo`);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/default-imports/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/default-imports/input.mjs
@@ -1,0 +1,2 @@
+import f from "mod";
+console.log(f);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/default-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/default-imports/output.mjs
@@ -1,0 +1,9 @@
+const _ns = _interopImportCJSNamespace(_nsOrig, true);
+
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+
+/*#__CJS__*/
+import * as _nsOrig from "mod";
+console.log(_ns.default);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/multiple-import-decls/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/multiple-import-decls/input.mjs
@@ -1,0 +1,9 @@
+import f from "mod1";
+import { a as x, b } from "mod2";
+import "mod1";
+import {} from "mod1";
+import { default as f2 } from "mod1";
+import * as ns2 from "mod2";
+import * as ns2b from "mod2";
+
+console.log({ f, x, b, f2, ns2, ns2b });

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/multiple-import-decls/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/multiple-import-decls/output.mjs
@@ -1,0 +1,38 @@
+const ns2b = _interopImportCJSNamespace(_nsOrig5, true);
+
+const ns2 = _interopImportCJSNamespace(_nsOrig4, true);
+
+const _ns3 = _interopImportCJSNamespace(_nsOrig3, true);
+
+const _ns2 = _interopImportCJSNamespace(_nsOrig2, true);
+
+const _ns = _interopImportCJSNamespace(_nsOrig, true);
+
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+
+/*#__CJS__*/
+import * as _nsOrig from "mod1";
+
+/*#__CJS__*/
+import * as _nsOrig2 from "mod2";
+import "mod1";
+import "mod1";
+
+/*#__CJS__*/
+import * as _nsOrig3 from "mod1";
+
+/*#__CJS__*/
+import * as _nsOrig4 from "mod2";
+
+/*#__CJS__*/
+import * as _nsOrig5 from "mod2";
+console.log({
+  f: _ns.default,
+  x: _ns2.a,
+  b: _ns2.b,
+  f2: _ns3.default,
+  ns2,
+  ns2b
+});

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/multiple-imports/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/multiple-imports/input.mjs
@@ -1,0 +1,2 @@
+import f, { a as x, b } from "mod";
+console.log({ f, x, b });

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/multiple-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/multiple-imports/output.mjs
@@ -1,0 +1,13 @@
+const _ns = _interopImportCJSNamespace(_nsOrig, true);
+
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+
+/*#__CJS__*/
+import * as _nsOrig from "mod";
+console.log({
+  f: _ns.default,
+  x: _ns.a,
+  b: _ns.b
+});

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/named-default-imports/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/named-default-imports/input.mjs
@@ -1,0 +1,2 @@
+import { default as f } from "mod";
+console.log(f);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/named-default-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/named-default-imports/output.mjs
@@ -1,0 +1,9 @@
+const _ns = _interopImportCJSNamespace(_nsOrig, true);
+
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+
+/*#__CJS__*/
+import * as _nsOrig from "mod";
+console.log(_ns.default);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/named-imports/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/named-imports/input.mjs
@@ -1,0 +1,2 @@
+import { f } from "mod";
+console.log(f);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/named-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/named-imports/output.mjs
@@ -1,0 +1,9 @@
+const _ns = _interopImportCJSNamespace(_nsOrig, true);
+
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+
+/*#__CJS__*/
+import * as _nsOrig from "mod";
+console.log(_ns.f);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/namespace-imports/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/namespace-imports/input.mjs
@@ -1,0 +1,2 @@
+import * as M from "mod";
+console.log(M);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/namespace-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/namespace-imports/output.mjs
@@ -1,0 +1,9 @@
+const M = _interopImportCJSNamespace(_nsOrig, true);
+
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+
+/*#__CJS__*/
+import * as _nsOrig from "mod";
+console.log(M);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/options.json
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/options.json
@@ -1,5 +1,8 @@
 {
   "plugins": [
-    ["babel-plugin-node-cjs-interop", { "packages": ["mod", "mod1", "mod2"], "loose": true }]
+    [
+      "babel-plugin-node-cjs-interop",
+      { "packages": ["mod", "mod1", "mod2"], "loose": true }
+    ]
   ]
 }

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/options.json
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    ["babel-plugin-node-cjs-interop", { "packages": ["mod", "mod1", "mod2"], "loose": true }]
+  ]
+}

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/side-effect-imports/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/side-effect-imports/input.mjs
@@ -1,0 +1,1 @@
+import "mod";

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/side-effect-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/side-effect-imports/output.mjs
@@ -1,0 +1,1 @@
+import "mod";

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/todo-forbidden-rewriting/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/todo-forbidden-rewriting/input.mjs
@@ -1,0 +1,4 @@
+import { v } from "mod";
+
+v = 42;
+[v] = [42];

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/todo-forbidden-rewriting/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/loose/todo-forbidden-rewriting/output.mjs
@@ -1,0 +1,10 @@
+const _ns = _interopImportCJSNamespace(_nsOrig, true);
+
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+
+/*#__CJS__*/
+import * as _nsOrig from "mod";
+v = 42;
+[v] = [42];

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/package-filtering/test/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/package-filtering/test/output.mjs
@@ -10,8 +10,8 @@ const _ns2 = _interopImportCJSNamespace(_nsOrig2);
 
 const _ns = _interopImportCJSNamespace(_nsOrig);
 
-function _interopImportCJSNamespace(ns) {
-  return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 
 /*#__CJS__*/

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/with-react/jsx/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/with-react/jsx/output.mjs
@@ -2,8 +2,8 @@ const ns = _interopImportCJSNamespace(_nsOrig2);
 
 const _ns = _interopImportCJSNamespace(_nsOrig);
 
-function _interopImportCJSNamespace(ns) {
-  return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 
 /*#__CJS__*/

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/with-typescript/basic/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/with-typescript/basic/output.mjs
@@ -2,8 +2,8 @@ const ns = _interopImportCJSNamespace(_nsOrig2);
 
 const _ns = _interopImportCJSNamespace(_nsOrig);
 
-function _interopImportCJSNamespace(ns) {
-  return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 
 /*#__CJS__*/

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/with-typescript/dual-use/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/with-typescript/dual-use/output.mjs
@@ -1,7 +1,7 @@
 const _ns = _interopImportCJSNamespace(_nsOrig);
 
-function _interopImportCJSNamespace(ns) {
-  return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+  return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 
 /*#__CJS__*/

--- a/packages/node-cjs-interop/CHANGELOG.md
+++ b/packages/node-cjs-interop/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 0.1.1
+
+Add `loose` parameter to `interopImportCJSNamespace` to support more libraries.
+
+## 0.1.0
+
+Initial release.

--- a/packages/node-cjs-interop/src/__fixtures__/module4.cjs
+++ b/packages/node-cjs-interop/src/__fixtures__/module4.cjs
@@ -1,0 +1,19 @@
+"use strict";
+
+function __define(obj, name, value) {
+  Object.defineProperty(obj, name, {
+    value: value
+  });
+}
+
+__define(exports, "__esModule", true);
+exports.version = exports.default = void 0;
+
+var _default = x => x * x;
+
+exports.default = _default;
+const version = "0.1.2";
+exports.version = version;
+
+// export default (x) => x * x;
+// export const version = "0.1.2";

--- a/packages/node-cjs-interop/src/__fixtures__/module4.cjs
+++ b/packages/node-cjs-interop/src/__fixtures__/module4.cjs
@@ -2,14 +2,14 @@
 
 function __define(obj, name, value) {
   Object.defineProperty(obj, name, {
-    value: value
+    value: value,
   });
 }
 
 __define(exports, "__esModule", true);
 exports.version = exports.default = void 0;
 
-var _default = x => x * x;
+var _default = (x) => x * x;
 
 exports.default = _default;
 const version = "0.1.2";

--- a/packages/node-cjs-interop/src/__fixtures__/module4.d.cts
+++ b/packages/node-cjs-interop/src/__fixtures__/module4.d.cts
@@ -1,0 +1,4 @@
+declare function square(x: number): number;
+export default square;
+
+export declare const version: string;

--- a/packages/node-cjs-interop/src/index.test.ts
+++ b/packages/node-cjs-interop/src/index.test.ts
@@ -3,6 +3,7 @@ import { interopImportCJSNamespace, interopImportCJSDefault } from ".";
 import * as module1 from "./__fixtures__/module1.cjs";
 import * as module2 from "./__fixtures__/module2.cjs";
 import * as module3 from "./__fixtures__/module3.mjs";
+import * as module4 from "./__fixtures__/module4.cjs";
 
 describe("interopImportCJSNamespace", () => {
   it("Returns the same value for pure CJS", () => {
@@ -22,6 +23,41 @@ describe("interopImportCJSNamespace", () => {
   it("Returns the same value for native ESM", () => {
     const wrapped = interopImportCJSNamespace(module3);
     expect(wrapped).toBe(module3);
+    expect(wrapped.default(42)).toBe(1764);
+    expect(wrapped.version).toBe("0.1.2");
+  });
+
+  it("Returns the same value for poorly-written transpiled CJS", () => {
+    const wrapped = interopImportCJSNamespace(module4);
+    expect(wrapped).toBe(module4);
+  });
+});
+
+describe("interopImportCJSNamespace with loose = true", () => {
+  it("Returns the same value for pure CJS", () => {
+    const wrapped = interopImportCJSNamespace(module1, true);
+    expect(wrapped).toBe(module1);
+    expect(wrapped.default(42)).toBe(1764);
+    expect(wrapped.version).toBe("0.1.2");
+  });
+
+  it("Returns the default value for transpiled CJS", () => {
+    const wrapped = interopImportCJSNamespace(module2, true);
+    expect(wrapped).toBe(module2.default);
+    expect(wrapped.default(42)).toBe(1764);
+    expect(wrapped.version).toBe("0.1.2");
+  });
+
+  it("Returns the same value for native ESM", () => {
+    const wrapped = interopImportCJSNamespace(module3, true);
+    expect(wrapped).toBe(module3);
+    expect(wrapped.default(42)).toBe(1764);
+    expect(wrapped.version).toBe("0.1.2");
+  });
+
+  it("Returns the default value for poorly-written transpiled CJS", () => {
+    const wrapped = interopImportCJSNamespace(module4, true);
+    expect(wrapped).toBe(module4.default);
     expect(wrapped.default(42)).toBe(1764);
     expect(wrapped.version).toBe("0.1.2");
   });
@@ -45,6 +81,14 @@ describe("interopImportCJSDefault", () => {
   it("Returns the same value for native ESM", () => {
     const wrapped = interopImportCJSDefault(module3.default);
     expect(wrapped).toBe(module3.default);
+    expect(wrapped(42)).toBe(1764);
+  });
+
+  it("Returns the default value for poorly-written transpiled CJS", () => {
+    const wrapped = interopImportCJSDefault(module4.default);
+    expect(wrapped).toBe(
+      (module4 as unknown as { default: typeof module4 }).default.default
+    );
     expect(wrapped(42)).toBe(1764);
   });
 });

--- a/packages/node-cjs-interop/src/index.ts
+++ b/packages/node-cjs-interop/src/index.ts
@@ -3,6 +3,9 @@
  * Node.js native ESM and Babel's ESM transpilation.
  *
  * @param ns the namespace object provided by Node.js
+ * @param loose skip checking the existence of `ns.__esModule`.
+ *        This is useful when cjs-module-lexer is unable to detect the
+ *        definition of `__esModule`.
  * @returns the adjusted namespace object
  * @example
  *   ```ts
@@ -11,11 +14,12 @@
  *   console.log([ns.foo, ns.default]);
  *   ```
  */
-export function interopImportCJSNamespace<T>(ns: T): T {
-  return (ns as NamespaceWrapper<T>).__esModule &&
-    (ns as NamespaceWrapper<T>).default &&
-    (ns as NamespaceWrapper<T>).default.__esModule
-    ? (ns as NamespaceWrapper<T>).default
+export function interopImportCJSNamespace<T>(ns: T, loose?: boolean): T {
+  type TT = NamespaceWrapper<T>;
+  return (loose || (ns as TT).__esModule) &&
+    (ns as TT).default &&
+    (ns as TT).default.__esModule
+    ? (ns as TT).default
     : ns;
 }
 

--- a/packages/swc-plugin-node-cjs-interop/CHANGELOG.md
+++ b/packages/swc-plugin-node-cjs-interop/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 0.1.1
+
+Add `loose` option to support more libraries.
+
+## 0.1.0
+
+Initial release.

--- a/packages/swc-plugin-node-cjs-interop/README.md
+++ b/packages/swc-plugin-node-cjs-interop/README.md
@@ -190,6 +190,17 @@ You can use [`node-cjs-interop-finder`](https://npmjs.com/package/node-cjs-inter
 npx node-cjs-interop-finder
 ```
 
+### loose
+
+- type: `boolean`
+- default: `false`
+
+Skips check of the `ns.__esModule` export. Note that it still checks
+for `ns.default.__esModule`.
+
+This is useful if a transpiler or a bundler generates a module
+which cjs-module-lexer cannot correctly parse.
+
 ### useRuntime
 
 - type: `boolean`

--- a/packages/swc-plugin-node-cjs-interop/src/options.rs
+++ b/packages/swc-plugin-node-cjs-interop/src/options.rs
@@ -7,5 +7,7 @@ pub struct Options {
     #[serde(default)]
     pub packages: Vec<String>,
     #[serde(default)]
+    pub loose: bool,
+    #[serde(default)]
     pub use_runtime: bool,
 }

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/call-replacement/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/call-replacement/output.mjs
@@ -1,6 +1,6 @@
 /*#__CJS__*/ const _ns = _interopImportCJSNamespace(_nsOrig);
-function _interopImportCJSNamespace(ns) {
-    return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 import * as _nsOrig from "mod";
 console.log((0, _ns.f)());

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/default-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/default-imports/output.mjs
@@ -1,6 +1,6 @@
 /*#__CJS__*/ const _ns = _interopImportCJSNamespace(_nsOrig);
-function _interopImportCJSNamespace(ns) {
-    return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 import * as _nsOrig from "mod";
 console.log(_ns.default);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/multiple-import-decls/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/multiple-import-decls/output.mjs
@@ -3,8 +3,8 @@ const ns2 = _interopImportCJSNamespace(_nsOrig3);
 const _ns = _interopImportCJSNamespace(_nsOrig2);
 const _ns1 = _interopImportCJSNamespace(_nsOrig1);
 const _ns2 = _interopImportCJSNamespace(_nsOrig);
-function _interopImportCJSNamespace(ns) {
-    return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 import * as _nsOrig from "mod1";
 /*#__CJS__*/ import * as _nsOrig1 from "mod2";

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/multiple-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/multiple-imports/output.mjs
@@ -1,6 +1,6 @@
 /*#__CJS__*/ const _ns = _interopImportCJSNamespace(_nsOrig);
-function _interopImportCJSNamespace(ns) {
-    return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 import * as _nsOrig from "mod";
 console.log({

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/named-default-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/named-default-imports/output.mjs
@@ -1,6 +1,6 @@
 /*#__CJS__*/ const _ns = _interopImportCJSNamespace(_nsOrig);
-function _interopImportCJSNamespace(ns) {
-    return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 import * as _nsOrig from "mod";
 console.log(_ns.default);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/named-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/named-imports/output.mjs
@@ -1,6 +1,6 @@
 /*#__CJS__*/ const _ns = _interopImportCJSNamespace(_nsOrig);
-function _interopImportCJSNamespace(ns) {
-    return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 import * as _nsOrig from "mod";
 console.log(_ns.f);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/namespace-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/namespace-imports/output.mjs
@@ -1,6 +1,6 @@
 /*#__CJS__*/ const M = _interopImportCJSNamespace(_nsOrig);
-function _interopImportCJSNamespace(ns) {
-    return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 import * as _nsOrig from "mod";
 console.log(M);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/todo-forbidden-rewriting/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/basic/todo-forbidden-rewriting/output.mjs
@@ -1,6 +1,6 @@
 /*#__CJS__*/ const _ns = _interopImportCJSNamespace(_nsOrig);
-function _interopImportCJSNamespace(ns) {
-    return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 import * as _nsOrig from "mod";
 v = 42;

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/braces-only-imports/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/braces-only-imports/input.mjs
@@ -1,0 +1,1 @@
+import {} from "mod";

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/braces-only-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/braces-only-imports/output.mjs
@@ -1,0 +1,1 @@
+import "mod";

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/call-replacement/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/call-replacement/input.mjs
@@ -1,0 +1,6 @@
+import { f } from "mod";
+
+console.log(f());
+console.log(f.g());
+console.log(f?.());
+console.log(f`foo`);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/call-replacement/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/call-replacement/output.mjs
@@ -1,0 +1,9 @@
+/*#__CJS__*/ const _ns = _interopImportCJSNamespace(_nsOrig, true);
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+import * as _nsOrig from "mod";
+console.log((0, _ns.f)());
+console.log(_ns.f.g());
+console.log((0, _ns.f)?.());
+console.log((0, _ns.f)`foo`);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/default-imports/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/default-imports/input.mjs
@@ -1,0 +1,2 @@
+import f from "mod";
+console.log(f);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/default-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/default-imports/output.mjs
@@ -1,0 +1,6 @@
+/*#__CJS__*/ const _ns = _interopImportCJSNamespace(_nsOrig, true);
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+import * as _nsOrig from "mod";
+console.log(_ns.default);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/multiple-import-decls/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/multiple-import-decls/input.mjs
@@ -1,0 +1,9 @@
+import f from "mod1";
+import { a as x, b } from "mod2";
+import "mod1";
+import {} from "mod1";
+import { default as f2 } from "mod1";
+import * as ns2 from "mod2";
+import * as ns2b from "mod2";
+
+console.log({ f, x, b, f2, ns2, ns2b });

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/multiple-import-decls/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/multiple-import-decls/output.mjs
@@ -1,0 +1,23 @@
+/*#__CJS__*/ const ns2b = _interopImportCJSNamespace(_nsOrig4, true);
+const ns2 = _interopImportCJSNamespace(_nsOrig3, true);
+const _ns = _interopImportCJSNamespace(_nsOrig2, true);
+const _ns1 = _interopImportCJSNamespace(_nsOrig1, true);
+const _ns2 = _interopImportCJSNamespace(_nsOrig, true);
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+import * as _nsOrig from "mod1";
+/*#__CJS__*/ import * as _nsOrig1 from "mod2";
+import "mod1";
+import "mod1";
+/*#__CJS__*/ import * as _nsOrig2 from "mod1";
+/*#__CJS__*/ import * as _nsOrig3 from "mod2";
+/*#__CJS__*/ import * as _nsOrig4 from "mod2";
+console.log({
+    f: _ns2.default,
+    x: _ns1.a,
+    b: _ns1.b,
+    f2: _ns.default,
+    ns2,
+    ns2b
+});

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/multiple-imports/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/multiple-imports/input.mjs
@@ -1,0 +1,2 @@
+import f, { a as x, b } from "mod";
+console.log({ f, x, b });

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/multiple-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/multiple-imports/output.mjs
@@ -1,0 +1,10 @@
+/*#__CJS__*/ const _ns = _interopImportCJSNamespace(_nsOrig, true);
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+import * as _nsOrig from "mod";
+console.log({
+    f: _ns.default,
+    x: _ns.a,
+    b: _ns.b
+});

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/named-default-imports/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/named-default-imports/input.mjs
@@ -1,0 +1,2 @@
+import { default as f } from "mod";
+console.log(f);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/named-default-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/named-default-imports/output.mjs
@@ -1,0 +1,6 @@
+/*#__CJS__*/ const _ns = _interopImportCJSNamespace(_nsOrig, true);
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+import * as _nsOrig from "mod";
+console.log(_ns.default);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/named-imports/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/named-imports/input.mjs
@@ -1,0 +1,2 @@
+import { f } from "mod";
+console.log(f);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/named-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/named-imports/output.mjs
@@ -1,0 +1,6 @@
+/*#__CJS__*/ const _ns = _interopImportCJSNamespace(_nsOrig, true);
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+import * as _nsOrig from "mod";
+console.log(_ns.f);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/namespace-imports/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/namespace-imports/input.mjs
@@ -1,0 +1,2 @@
+import * as M from "mod";
+console.log(M);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/namespace-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/namespace-imports/output.mjs
@@ -1,0 +1,6 @@
+/*#__CJS__*/ const M = _interopImportCJSNamespace(_nsOrig, true);
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+import * as _nsOrig from "mod";
+console.log(M);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/side-effect-imports/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/side-effect-imports/input.mjs
@@ -1,0 +1,1 @@
+import "mod";

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/side-effect-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/side-effect-imports/output.mjs
@@ -1,0 +1,1 @@
+import "mod";

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/todo-forbidden-rewriting/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/todo-forbidden-rewriting/input.mjs
@@ -1,0 +1,4 @@
+import { v } from "mod";
+
+v = 42;
+[v] = [42];

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/todo-forbidden-rewriting/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/loose/todo-forbidden-rewriting/output.mjs
@@ -1,0 +1,9 @@
+/*#__CJS__*/ const _ns = _interopImportCJSNamespace(_nsOrig, true);
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+}
+import * as _nsOrig from "mod";
+v = 42;
+[v] = [
+    42
+];

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/package-filtering/test/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/package-filtering/test/output.mjs
@@ -4,8 +4,8 @@ const _ns2 = _interopImportCJSNamespace(_nsOrig3);
 const _ns3 = _interopImportCJSNamespace(_nsOrig2);
 const _ns4 = _interopImportCJSNamespace(_nsOrig1);
 const _ns5 = _interopImportCJSNamespace(_nsOrig);
-function _interopImportCJSNamespace(ns) {
-    return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 import * as _nsOrig from "foo";
 /*#__CJS__*/ import * as _nsOrig1 from "bar";

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/with-react/jsx/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/with-react/jsx/output.mjs
@@ -1,7 +1,7 @@
 /*#__CJS__*/ const ns = _interopImportCJSNamespace(_nsOrig1);
 const _ns = _interopImportCJSNamespace(_nsOrig);
-function _interopImportCJSNamespace(ns) {
-    return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 import * as _nsOrig from "mod";
 /*#__CJS__*/ import * as _nsOrig1 from "mod2";

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/with-typescript/basic/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/with-typescript/basic/output.mjs
@@ -2,8 +2,8 @@
 const ns2 = _interopImportCJSNamespace(_nsOrig2);
 const ns = _interopImportCJSNamespace(_nsOrig1);
 const _ns = _interopImportCJSNamespace(_nsOrig);
-function _interopImportCJSNamespace(ns) {
-    return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 /*#__CJS__*/ import * as _nsOrig from "mod";
 /*#__CJS__*/ import * as _nsOrig1 from "mod";

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/with-typescript/dual-use/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/with-typescript/dual-use/output.mjs
@@ -1,7 +1,7 @@
 // @ts-nocheck
 /*#__CJS__*/ const _ns = _interopImportCJSNamespace(_nsOrig);
-function _interopImportCJSNamespace(ns) {
-    return ns.__esModule && ns.default && ns.default.__esModule ? ns.default : ns;
+function _interopImportCJSNamespace(ns, loose) {
+    return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
 }
 import * as _nsOrig from "mod";
 console.log({

--- a/packages/swc-plugin-node-cjs-interop/tests/index.rs
+++ b/packages/swc-plugin-node-cjs-interop/tests/index.rs
@@ -16,6 +16,27 @@ fn test_basic(input: PathBuf) {
                 t.comments.clone(),
                 TransformOptions {
                     packages: vec!["mod".to_owned(), "mod1".to_owned(), "mod2".to_owned()],
+                    loose: false,
+                    use_runtime: false,
+                },
+            ))
+        },
+        &input,
+        &output,
+    );
+}
+
+#[testing::fixture("tests/fixtures/loose/*/input.mjs")]
+fn test_loose(input: PathBuf) {
+    let output = input.with_file_name("output.mjs");
+    test_fixture(
+        Syntax::Es(EsConfig::default()),
+        &|t| {
+            as_folder(TransformVisitor::new(
+                t.comments.clone(),
+                TransformOptions {
+                    packages: vec!["mod".to_owned(), "mod1".to_owned(), "mod2".to_owned()],
+                    loose: true,
                     use_runtime: false,
                 },
             ))
@@ -40,6 +61,7 @@ fn test_package_filtering(input: PathBuf) {
                         "@scoped/foo".to_owned(),
                         "@scoped/bar".to_owned(),
                     ],
+                    loose: false,
                     use_runtime: false,
                 },
             ))
@@ -59,6 +81,7 @@ fn test_use_runtime(input: PathBuf) {
                 t.comments.clone(),
                 TransformOptions {
                     packages: vec!["mod".to_owned(), "mod1".to_owned(), "mod2".to_owned()],
+                    loose: false,
                     use_runtime: true,
                 },
             ))
@@ -81,6 +104,7 @@ fn test_with_react(input: PathBuf) {
                 t.comments.clone(),
                 TransformOptions {
                     packages: vec!["mod".to_owned(), "mod2".to_owned()],
+                    loose: false,
                     use_runtime: false,
                 },
             ))
@@ -101,6 +125,7 @@ fn test_with_typescript(input: PathBuf) {
                     t.comments.clone(),
                     TransformOptions {
                         packages: vec!["mod".to_owned()],
+                        loose: false,
                         use_runtime: false,
                     },
                 )),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3443,6 +3443,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"fixture-package-mangled-babel-esm@workspace:*, fixture-package-mangled-babel-esm@workspace:e2e/fixture-package-mangled-babel-esm":
+  version: 0.0.0-use.local
+  resolution: "fixture-package-mangled-babel-esm@workspace:e2e/fixture-package-mangled-babel-esm"
+  languageName: unknown
+  linkType: soft
+
 "fixture-package-native-esm@workspace:*, fixture-package-native-esm@workspace:e2e/fixture-package-native-esm":
   version: 0.0.0-use.local
   resolution: "fixture-package-native-esm@workspace:e2e/fixture-package-native-esm"
@@ -5955,6 +5961,7 @@ __metadata:
     eslint-config-prettier: ^8.3.0
     eslint-plugin-jest: ^25.3.0
     fixture-package-babel-esm: "workspace:*"
+    fixture-package-mangled-babel-esm: "workspace:*"
     fixture-package-native-esm: "workspace:*"
     fixture-package-pure-cjs: "workspace:*"
     jest: ^27.4.4


### PR DESCRIPTION
Sometimes the proxy module doesn't export `__esModule` because cjs-module-lexer cannot detect the definition.

To aid this case, add the `loose` option to skip checking `ns.__esModule` and rely solely on `ns.default.__esModule`.
