### PR TITLE
Add twisted variant

### DIFF
--- a/.changeset/chilled-timers-listen.md
+++ b/.changeset/chilled-timers-listen.md
@@ -1,0 +1,12 @@
+---
+"babel-plugin-node-cjs-interop": patch
+"swc-plugin-node-cjs-interop": patch
+"node-cjs-interop": patch
+---
+
+Add a variant helper that wraps default one more time.
+
+The helper is called `interopImportCJSNamespaceT` and you can use it just like `interopImportCJSNamespace`
+(except that it assumes `loose = true` by default).
+
+To use it from the Babel/SWC plugins, use the `packagesT` option instead of `packages`.

--- a/packages/babel-plugin-node-cjs-interop/README.md
+++ b/packages/babel-plugin-node-cjs-interop/README.md
@@ -193,6 +193,18 @@ You can use [`node-cjs-interop-finder`](https://npmjs.com/package/node-cjs-inter
 npx node-cjs-interop-finder
 ```
 
+### packagesT
+
+- type: `string[]`
+- default: `[]`
+
+Similar to `packages`, but applies the "twisted" variant instead. In this mode, the imported `default` value
+would be the namespace object rather than the proper default export.
+
+This is useful when you have `"module"` or `"moduleResolution"` set to `"nodenext"` or `"node16"`
+in your `tsconfig.json` and you need to import `default` from a "dual package" in which the
+type definitions are recognized in the `.cts` mode.
+
 ### loose
 
 - type: `boolean`

--- a/packages/babel-plugin-node-cjs-interop/src/index.ts
+++ b/packages/babel-plugin-node-cjs-interop/src/index.ts
@@ -26,7 +26,8 @@ export default declare<Options, Babel.PluginObj>((api, options) => {
     name: "babel-plugin-node-cjs-interop",
     visitor: {
       ImportDeclaration(path, state) {
-        if (!hasApplicableSource(path.node.source.value, options)) return;
+        const pkgType = applicableSourceType(path.node.source.value, options);
+        if (!pkgType) return;
         // Should have been removed by transform-typescript. Just in case.
         if (path.node.importKind === "type") return;
         if (isCjsAnnotated(path.node)) return;
@@ -79,6 +80,7 @@ export default declare<Options, Babel.PluginObj>((api, options) => {
           t,
           path,
           state,
+          pkgType,
           options.useRuntime ?? false,
         );
 
@@ -96,7 +98,9 @@ export default declare<Options, Babel.PluginObj>((api, options) => {
               nsImport,
               t.callExpression(t.cloneNode(importHelper), [
                 t.cloneNode(importOriginalName),
-                ...(options.loose ? [t.booleanLiteral(true)] : []),
+                ...(pkgType !== "ts-twisted" && options.loose
+                  ? [t.booleanLiteral(true)]
+                  : []),
               ]),
             ),
           ]),
@@ -136,7 +140,8 @@ export default declare<Options, Babel.PluginObj>((api, options) => {
       },
       ExportNamedDeclaration(path) {
         if (!path.node.source) return;
-        if (!hasApplicableSource(path.node.source.value, options)) return;
+        const pkgType = applicableSourceType(path.node.source.value, options);
+        if (!pkgType) return;
         // Should have been removed by transform-typescript. Just in case.
         if (path.node.exportKind === "type") return;
         if (isCjsAnnotated(path.node)) return;
@@ -148,7 +153,8 @@ export default declare<Options, Babel.PluginObj>((api, options) => {
       },
       ExportAllDeclaration(path) {
         if (!path.node.source) return;
-        if (!hasApplicableSource(path.node.source.value, options)) return;
+        const pkgType = applicableSourceType(path.node.source.value, options);
+        if (!pkgType) return;
         // Should have been removed by transform-typescript. Just in case.
         if (path.node.exportKind === "type") return;
         if (isCjsAnnotated(path.node)) return;
@@ -170,14 +176,22 @@ function getImportHelper(
   t: typeof Babel.types,
   path: Babel.NodePath,
   state: Babel.PluginPass,
+  pkgType: PackageType,
   useRuntime: boolean,
 ): Identifier {
-  const key = `${statePrefix}/importHelper`;
+  const key =
+    pkgType === "ts-twisted"
+      ? `${statePrefix}/importHelperT`
+      : `${statePrefix}/importHelper`;
   let helper = state.get(key) as Identifier | undefined;
   if (helper) return helper;
 
+  const helperName =
+    pkgType === "ts-twisted"
+      ? "interopImportCJSNamespaceT"
+      : "interopImportCJSNamespace";
   const scope = path.scope.getProgramParent();
-  helper = scope.generateUidIdentifier("interopImportCJSNamespace");
+  helper = scope.generateUidIdentifier(helperName);
 
   if (useRuntime) {
     // import {
@@ -186,12 +200,7 @@ function getImportHelper(
     (scope.path as Babel.NodePath<Program>).unshiftContainer(
       "body",
       t.importDeclaration(
-        [
-          t.importSpecifier(
-            t.cloneNode(helper),
-            t.identifier("interopImportCJSNamespace"),
-          ),
-        ],
+        [t.importSpecifier(t.cloneNode(helper), t.identifier(helperName))],
         t.stringLiteral("node-cjs-interop"),
       ),
     );
@@ -205,43 +214,84 @@ function getImportHelper(
     t.cloneNode(ns),
     t.identifier("default"),
   );
-  // function interopImportCJSNamespace(ns, loose) {
-  //   return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
-  // }
-  (scope.path as Babel.NodePath<Program>).unshiftContainer(
-    "body",
-    t.functionDeclaration(
-      t.cloneNode(helper),
-      [t.cloneNode(ns), t.cloneNode(loose)],
-      t.blockStatement([
-        t.returnStatement(
-          t.conditionalExpression(
-            t.logicalExpression(
-              "&&",
+
+  if (pkgType === "ts-twisted") {
+    // function interopImportCJSNamespaceT(ns) {
+    //   return ns.default && ns.default.__esModule ? ns : {
+    //     ...ns,
+    //     default: ns
+    //   };
+    // }
+    (scope.path as Babel.NodePath<Program>).unshiftContainer(
+      "body",
+      t.functionDeclaration(
+        t.cloneNode(helper),
+        [t.cloneNode(ns)],
+        t.blockStatement([
+          t.returnStatement(
+            t.conditionalExpression(
+              t.logicalExpression(
+                "&&",
+                t.cloneNode(nsDefault),
+                t.memberExpression(
+                  t.cloneNode(nsDefault),
+                  t.identifier("__esModule"),
+                ),
+              ),
+              t.cloneNode(ns),
+              t.objectExpression([
+                t.spreadElement(t.cloneNode(ns)),
+                t.objectProperty(
+                  t.identifier("default"),
+                  t.cloneNode(ns),
+                  false,
+                  false,
+                ),
+              ]),
+            ),
+          ),
+        ]),
+      ),
+    );
+  } else {
+    // function interopImportCJSNamespace(ns, loose) {
+    //   return (loose || ns.__esModule) && ns.default && ns.default.__esModule ? ns.default : ns;
+    // }
+    (scope.path as Babel.NodePath<Program>).unshiftContainer(
+      "body",
+      t.functionDeclaration(
+        t.cloneNode(helper),
+        [t.cloneNode(ns), t.cloneNode(loose)],
+        t.blockStatement([
+          t.returnStatement(
+            t.conditionalExpression(
               t.logicalExpression(
                 "&&",
                 t.logicalExpression(
-                  "||",
-                  t.cloneNode(loose),
-                  t.memberExpression(
-                    t.cloneNode(ns),
-                    t.identifier("__esModule"),
+                  "&&",
+                  t.logicalExpression(
+                    "||",
+                    t.cloneNode(loose),
+                    t.memberExpression(
+                      t.cloneNode(ns),
+                      t.identifier("__esModule"),
+                    ),
                   ),
+                  t.cloneNode(nsDefault),
                 ),
-                t.cloneNode(nsDefault),
+                t.memberExpression(
+                  t.cloneNode(nsDefault),
+                  t.identifier("__esModule"),
+                ),
               ),
-              t.memberExpression(
-                t.cloneNode(nsDefault),
-                t.identifier("__esModule"),
-              ),
+              t.cloneNode(nsDefault),
+              t.cloneNode(ns),
             ),
-            t.cloneNode(nsDefault),
-            t.cloneNode(ns),
           ),
-        ),
-      ]),
-    ),
-  );
+        ]),
+      ),
+    );
+  }
   state.set(key, helper);
   return helper;
 }
@@ -259,13 +309,22 @@ function annotateAsCjs(t: typeof Babel.types, node: Node): void {
   t.addComment(node, "leading", CJS_ANNOTATION);
 }
 
-function hasApplicableSource(source: string, options: Options): boolean {
-  const { packages = [] } = options;
+type PackageType = "normal" | "ts-twisted";
+function applicableSourceType(
+  source: string,
+  options: Options,
+): PackageType | undefined {
+  const { packages = [], packagesT = [] } = options;
 
   const sourcePackage = getPackageName(source);
-  if (sourcePackage === undefined) return false;
+  if (sourcePackage === undefined) return undefined;
 
-  return packages.includes(sourcePackage);
+  if (packages.includes(sourcePackage)) {
+    return "normal";
+  } else if (packagesT.includes(sourcePackage)) {
+    return "ts-twisted";
+  }
+  return undefined;
 }
 
 function replaceIdentifier(

--- a/packages/babel-plugin-node-cjs-interop/src/options.ts
+++ b/packages/babel-plugin-node-cjs-interop/src/options.ts
@@ -5,12 +5,14 @@ const v: OptionValidator = new OptionValidator("babel-plugin-node-cjs-interop");
 
 export type Options = {
   packages?: string[] | undefined;
+  packagesT?: string[] | undefined;
   loose?: boolean;
   useRuntime?: boolean;
 };
 
 const optionShape = {
   packages: "string[]",
+  packagesT: "string[]",
   loose: "boolean",
   useRuntime: "boolean",
 } as const;
@@ -18,12 +20,14 @@ const optionShape = {
 export function validateOptions(options: object): asserts options is Options {
   v.validateTopLevelOptions(options, optionShape);
   validatePackages(options.packages);
+  validatePackages(options.packagesT);
   v.validateBooleanOption("loose", options.loose as boolean | undefined);
   v.validateBooleanOption(
     "useRuntime",
     options.useRuntime as boolean | undefined,
   );
   validatePackagesSemantics(options.packages ?? []);
+  validatePackagesSemantics(options.packagesT ?? []);
 }
 
 function validatePackages(

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/braces-only-imports/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/braces-only-imports/input.mjs
@@ -1,0 +1,1 @@
+import {} from "mod";

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/braces-only-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/braces-only-imports/output.mjs
@@ -1,0 +1,1 @@
+import "mod";

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/call-replacement/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/call-replacement/input.mjs
@@ -1,0 +1,6 @@
+import { f } from "mod";
+
+console.log(f());
+console.log(f.g());
+console.log(f?.());
+console.log(f`foo`);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/call-replacement/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/call-replacement/output.mjs
@@ -1,0 +1,13 @@
+const _ns = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+  return ns.default && ns.default.__esModule ? ns : {
+    ...ns,
+    default: ns
+  };
+}
+/*#__CJS__*/
+import * as _nsOrig from "mod";
+console.log((0, _ns.f)());
+console.log(_ns.f.g());
+console.log((0, _ns.f)?.());
+console.log((0, _ns.f)`foo`);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/default-imports/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/default-imports/input.mjs
@@ -1,0 +1,2 @@
+import f from "mod";
+console.log(f);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/default-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/default-imports/output.mjs
@@ -1,0 +1,10 @@
+const _ns = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+  return ns.default && ns.default.__esModule ? ns : {
+    ...ns,
+    default: ns
+  };
+}
+/*#__CJS__*/
+import * as _nsOrig from "mod";
+console.log(_ns.default);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/multiple-import-decls/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/multiple-import-decls/input.mjs
@@ -1,0 +1,9 @@
+import f from "mod1";
+import { a as x, b } from "mod2";
+import "mod1";
+import {} from "mod1";
+import { default as f2 } from "mod1";
+import * as ns2 from "mod2";
+import * as ns2b from "mod2";
+
+console.log({ f, x, b, f2, ns2, ns2b });

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/multiple-import-decls/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/multiple-import-decls/output.mjs
@@ -1,0 +1,31 @@
+const ns2b = _interopImportCJSNamespaceT(_nsOrig5);
+const ns2 = _interopImportCJSNamespaceT(_nsOrig4);
+const _ns3 = _interopImportCJSNamespaceT(_nsOrig3);
+const _ns2 = _interopImportCJSNamespaceT(_nsOrig2);
+const _ns = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+  return ns.default && ns.default.__esModule ? ns : {
+    ...ns,
+    default: ns
+  };
+}
+/*#__CJS__*/
+import * as _nsOrig from "mod1";
+/*#__CJS__*/
+import * as _nsOrig2 from "mod2";
+import "mod1";
+import "mod1";
+/*#__CJS__*/
+import * as _nsOrig3 from "mod1";
+/*#__CJS__*/
+import * as _nsOrig4 from "mod2";
+/*#__CJS__*/
+import * as _nsOrig5 from "mod2";
+console.log({
+  f: _ns.default,
+  x: _ns2.a,
+  b: _ns2.b,
+  f2: _ns3.default,
+  ns2,
+  ns2b
+});

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/multiple-imports/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/multiple-imports/input.mjs
@@ -1,0 +1,2 @@
+import f, { a as x, b } from "mod";
+console.log({ f, x, b });

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/multiple-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/multiple-imports/output.mjs
@@ -1,0 +1,14 @@
+const _ns = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+  return ns.default && ns.default.__esModule ? ns : {
+    ...ns,
+    default: ns
+  };
+}
+/*#__CJS__*/
+import * as _nsOrig from "mod";
+console.log({
+  f: _ns.default,
+  x: _ns.a,
+  b: _ns.b
+});

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/named-default-imports/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/named-default-imports/input.mjs
@@ -1,0 +1,2 @@
+import { default as f } from "mod";
+console.log(f);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/named-default-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/named-default-imports/output.mjs
@@ -1,0 +1,10 @@
+const _ns = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+  return ns.default && ns.default.__esModule ? ns : {
+    ...ns,
+    default: ns
+  };
+}
+/*#__CJS__*/
+import * as _nsOrig from "mod";
+console.log(_ns.default);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/named-imports/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/named-imports/input.mjs
@@ -1,0 +1,2 @@
+import { f } from "mod";
+console.log(f);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/named-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/named-imports/output.mjs
@@ -1,0 +1,10 @@
+const _ns = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+  return ns.default && ns.default.__esModule ? ns : {
+    ...ns,
+    default: ns
+  };
+}
+/*#__CJS__*/
+import * as _nsOrig from "mod";
+console.log(_ns.f);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/namespace-imports/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/namespace-imports/input.mjs
@@ -1,0 +1,2 @@
+import * as M from "mod";
+console.log(M);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/namespace-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/namespace-imports/output.mjs
@@ -1,0 +1,10 @@
+const M = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+  return ns.default && ns.default.__esModule ? ns : {
+    ...ns,
+    default: ns
+  };
+}
+/*#__CJS__*/
+import * as _nsOrig from "mod";
+console.log(M);

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/options.json
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    ["../../../cjs/dist/index.js", { "packagesT": ["mod", "mod1", "mod2"] }]
+  ]
+}

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/side-effect-imports/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/side-effect-imports/input.mjs
@@ -1,0 +1,1 @@
+import "mod";

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/side-effect-imports/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/side-effect-imports/output.mjs
@@ -1,0 +1,1 @@
+import "mod";

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/todo-forbidden-rewriting/input.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/todo-forbidden-rewriting/input.mjs
@@ -1,0 +1,4 @@
+import { v } from "mod";
+
+v = 42;
+[v] = [42];

--- a/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/todo-forbidden-rewriting/output.mjs
+++ b/packages/babel-plugin-node-cjs-interop/test/fixtures/ts-twisted/todo-forbidden-rewriting/output.mjs
@@ -1,0 +1,11 @@
+const _ns = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+  return ns.default && ns.default.__esModule ? ns : {
+    ...ns,
+    default: ns
+  };
+}
+/*#__CJS__*/
+import * as _nsOrig from "mod";
+v = 42;
+[v] = [42];

--- a/packages/node-cjs-interop/README.md
+++ b/packages/node-cjs-interop/README.md
@@ -117,3 +117,24 @@ const CustomDiv = ns.default.div`...`;
 ```
 
 However, using [`babel-plugin-node-cjs-interop`](https://npmjs.com/package/babel-plugin-node-cjs-interop) is recommend over manual wrapping.
+
+## The "twisted" variant
+
+You can also use the "twisted" variant of the functions:
+
+```javascript
+import { interopImportCJSNamespaceT } from "node-cjs-interop";
+import * as TextareaAutosizeOrig from "react-textarea-autosize";
+
+const {
+  default: { default: TextareaAutosize },
+} = interopImportCJSNamespaceT(TextareaAutosizeOrig);
+```
+
+This is useful when you have `"module"` or `"moduleResolution"` set to `"nodenext"` or `"node16"`
+in your `tsconfig.json` and you need to import `default` from a "dual package" in which the
+type definitions are recognized in the `.cts` mode.
+
+There is no such thing as `interopImportCJSDefaultT` because in this mode, the imported `default` value
+would be the namespace object, and if it was originally the proper default export
+(i.e. in case it was imported like ESM), there is no way to reconstruct the whole namespace object from it.

--- a/packages/node-cjs-interop/src/index.test.ts
+++ b/packages/node-cjs-interop/src/index.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "@jest/globals";
-import { interopImportCJSNamespace, interopImportCJSDefault } from ".";
+import {
+  interopImportCJSNamespace,
+  interopImportCJSNamespaceT,
+  interopImportCJSDefault,
+} from ".";
 import * as module1 from "./__fixtures__/module1.cjs";
 import * as module2 from "./__fixtures__/module2.cjs";
 import * as module3 from "./__fixtures__/module3.mjs";
@@ -59,6 +63,28 @@ describe("interopImportCJSNamespace with loose = true", () => {
     const wrapped = interopImportCJSNamespace(module4, true);
     expect(wrapped).toBe(module4.default);
     expect(wrapped.default(42)).toBe(1764);
+    expect(wrapped.version).toBe("0.1.2");
+  });
+});
+
+describe("interopImportCJSNamespaceT", () => {
+  it("Returns a wrapped value for transpiled CJS", () => {
+    const wrapped = interopImportCJSNamespaceT(
+      // Reinterpret type to simulate "module": "nodenext" behavior
+      module2 as typeof module2 & { default: typeof module2 },
+    );
+    expect(wrapped.default).toBe(module2.default);
+    expect(wrapped.default.default(42)).toBe(1764);
+    expect(wrapped.version).toBe("0.1.2");
+  });
+
+  it("Returns the default value for poorly-written transpiled CJS", () => {
+    const wrapped = interopImportCJSNamespaceT(
+      // Reinterpret type to simulate "module": "nodenext" behavior
+      module4 as typeof module4 & { default: typeof module4 },
+    );
+    expect(wrapped.default).toBe(module4.default);
+    expect(wrapped.default.default(42)).toBe(1764);
     expect(wrapped.version).toBe("0.1.2");
   });
 });

--- a/packages/node-cjs-interop/src/index.ts
+++ b/packages/node-cjs-interop/src/index.ts
@@ -24,6 +24,40 @@ export function interopImportCJSNamespace<T>(ns: T, loose?: boolean): T {
 }
 
 /**
+ * Adjusts a namespace object to allow interoperation between
+ * Node.js native ESM and Babel's ESM transpilation.
+ *
+ * This is an alternative to {@link interopImportCJSNamespace} that
+ * aligns with skew default-import mode. This is useful when all of
+ * the following conditions are met:
+ *
+ * - You have "module" or "moduleResolution" set to "node16" or "nodenext"
+ * - Your source code is in ESM mode. That is:
+ *   - The extension is ".mjs" or ".mts"
+ *   - or the extension is ".js", ".ts", ".jsx", or ".tsx" and you have
+ *     "type": "module" in your package.json
+ * - The module you are importing is in CJS mode. That is:
+ *   - The extension is ".cjs" or ".cts"
+ *   - or the extension is ".js", ".ts", ".jsx", or ".tsx" and you have
+ *     "type": "commonjs" in your package.json
+ *
+ * @param ns the namespace object provided by Node.js
+ * @returns the adjusted namespace object
+ * @example
+ *   ```ts
+ *   import * as nsOrig from "mod";
+ *   const ns = interopImportCJSNamespaceT(nsOrig);
+ *   console.log([ns.default.foo, ns.default.default]);
+ *   ```
+ */
+export function interopImportCJSNamespaceT<T>(ns: T): T {
+  type TT = NamespaceWrapper<T>;
+  return (ns as TT).default && (ns as TT).default.__esModule
+    ? ns
+    : { ...ns, default: ns };
+}
+
+/**
  * Adjusts a default imported object to allow interoperation between
  * Node.js native ESM and Babel's ESM transpilation.
  *

--- a/packages/swc-plugin-node-cjs-interop/README.md
+++ b/packages/swc-plugin-node-cjs-interop/README.md
@@ -190,6 +190,18 @@ You can use [`node-cjs-interop-finder`](https://npmjs.com/package/node-cjs-inter
 npx node-cjs-interop-finder
 ```
 
+### packagesT
+
+- type: `string[]`
+- default: `[]`
+
+Similar to `packages`, but applies the "twisted" variant instead. In this mode, the imported `default` value
+would be the namespace object rather than the proper default export.
+
+This is useful when you have `"module"` or `"moduleResolution"` set to `"nodenext"` or `"node16"`
+in your `tsconfig.json` and you need to import `default` from a "dual package" in which the
+type definitions are recognized in the `.cts` mode.
+
 ### loose
 
 - type: `boolean`

--- a/packages/swc-plugin-node-cjs-interop/src/options.rs
+++ b/packages/swc-plugin-node-cjs-interop/src/options.rs
@@ -7,6 +7,8 @@ pub struct Options {
     #[serde(default)]
     pub packages: Vec<String>,
     #[serde(default)]
+    pub packages_t: Vec<String>,
+    #[serde(default)]
     pub loose: bool,
     #[serde(default)]
     pub use_runtime: bool,

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/braces-only-imports/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/braces-only-imports/input.mjs
@@ -1,0 +1,1 @@
+import {} from "mod";

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/braces-only-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/braces-only-imports/output.mjs
@@ -1,0 +1,1 @@
+import "mod";

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/call-replacement/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/call-replacement/input.mjs
@@ -1,0 +1,6 @@
+import { f } from "mod";
+
+console.log(f());
+console.log(f.g());
+console.log(f?.());
+console.log(f`foo`);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/call-replacement/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/call-replacement/output.mjs
@@ -1,0 +1,12 @@
+/*#__CJS__*/ const _ns = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+    return ns.default && ns.default.__esModule ? ns : {
+        ...ns,
+        default: ns
+    };
+}
+import * as _nsOrig from "mod";
+console.log((0, _ns.f)());
+console.log(_ns.f.g());
+console.log((0, _ns.f)?.());
+console.log((0, _ns.f)`foo`);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/default-imports/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/default-imports/input.mjs
@@ -1,0 +1,2 @@
+import f from "mod";
+console.log(f);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/default-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/default-imports/output.mjs
@@ -1,0 +1,9 @@
+/*#__CJS__*/ const _ns = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+    return ns.default && ns.default.__esModule ? ns : {
+        ...ns,
+        default: ns
+    };
+}
+import * as _nsOrig from "mod";
+console.log(_ns.default);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/multiple-import-decls/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/multiple-import-decls/input.mjs
@@ -1,0 +1,9 @@
+import f from "mod1";
+import { a as x, b } from "mod2";
+import "mod1";
+import {} from "mod1";
+import { default as f2 } from "mod1";
+import * as ns2 from "mod2";
+import * as ns2b from "mod2";
+
+console.log({ f, x, b, f2, ns2, ns2b });

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/multiple-import-decls/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/multiple-import-decls/output.mjs
@@ -1,0 +1,50 @@
+/*#__CJS__*/ const ns2b = _interopImportCJSNamespaceT(_nsOrig4);
+function _interopImportCJSNamespaceT(ns) {
+    return ns.default && ns.default.__esModule ? ns : {
+        ...ns,
+        default: ns
+    };
+}
+const ns2 = _interopImportCJSNamespaceT1(_nsOrig3);
+function _interopImportCJSNamespaceT1(ns) {
+    return ns.default && ns.default.__esModule ? ns : {
+        ...ns,
+        default: ns
+    };
+}
+const _ns = _interopImportCJSNamespaceT2(_nsOrig2);
+function _interopImportCJSNamespaceT2(ns) {
+    return ns.default && ns.default.__esModule ? ns : {
+        ...ns,
+        default: ns
+    };
+}
+const _ns1 = _interopImportCJSNamespaceT3(_nsOrig1);
+function _interopImportCJSNamespaceT3(ns) {
+    return ns.default && ns.default.__esModule ? ns : {
+        ...ns,
+        default: ns
+    };
+}
+const _ns2 = _interopImportCJSNamespaceT4(_nsOrig);
+function _interopImportCJSNamespaceT4(ns) {
+    return ns.default && ns.default.__esModule ? ns : {
+        ...ns,
+        default: ns
+    };
+}
+import * as _nsOrig from "mod1";
+/*#__CJS__*/ import * as _nsOrig1 from "mod2";
+import "mod1";
+import "mod1";
+/*#__CJS__*/ import * as _nsOrig2 from "mod1";
+/*#__CJS__*/ import * as _nsOrig3 from "mod2";
+/*#__CJS__*/ import * as _nsOrig4 from "mod2";
+console.log({
+    f: _ns2.default,
+    x: _ns1.a,
+    b: _ns1.b,
+    f2: _ns.default,
+    ns2,
+    ns2b
+});

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/multiple-imports/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/multiple-imports/input.mjs
@@ -1,0 +1,2 @@
+import f, { a as x, b } from "mod";
+console.log({ f, x, b });

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/multiple-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/multiple-imports/output.mjs
@@ -1,0 +1,13 @@
+/*#__CJS__*/ const _ns = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+    return ns.default && ns.default.__esModule ? ns : {
+        ...ns,
+        default: ns
+    };
+}
+import * as _nsOrig from "mod";
+console.log({
+    f: _ns.default,
+    x: _ns.a,
+    b: _ns.b
+});

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/named-default-imports/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/named-default-imports/input.mjs
@@ -1,0 +1,2 @@
+import { default as f } from "mod";
+console.log(f);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/named-default-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/named-default-imports/output.mjs
@@ -1,0 +1,9 @@
+/*#__CJS__*/ const _ns = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+    return ns.default && ns.default.__esModule ? ns : {
+        ...ns,
+        default: ns
+    };
+}
+import * as _nsOrig from "mod";
+console.log(_ns.default);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/named-imports/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/named-imports/input.mjs
@@ -1,0 +1,2 @@
+import { f } from "mod";
+console.log(f);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/named-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/named-imports/output.mjs
@@ -1,0 +1,9 @@
+/*#__CJS__*/ const _ns = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+    return ns.default && ns.default.__esModule ? ns : {
+        ...ns,
+        default: ns
+    };
+}
+import * as _nsOrig from "mod";
+console.log(_ns.f);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/namespace-imports/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/namespace-imports/input.mjs
@@ -1,0 +1,2 @@
+import * as M from "mod";
+console.log(M);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/namespace-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/namespace-imports/output.mjs
@@ -1,0 +1,9 @@
+/*#__CJS__*/ const M = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+    return ns.default && ns.default.__esModule ? ns : {
+        ...ns,
+        default: ns
+    };
+}
+import * as _nsOrig from "mod";
+console.log(M);

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/side-effect-imports/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/side-effect-imports/input.mjs
@@ -1,0 +1,1 @@
+import "mod";

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/side-effect-imports/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/side-effect-imports/output.mjs
@@ -1,0 +1,1 @@
+import "mod";

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/todo-forbidden-rewriting/input.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/todo-forbidden-rewriting/input.mjs
@@ -1,0 +1,4 @@
+import { v } from "mod";
+
+v = 42;
+[v] = [42];

--- a/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/todo-forbidden-rewriting/output.mjs
+++ b/packages/swc-plugin-node-cjs-interop/tests/fixtures/ts-twisted/todo-forbidden-rewriting/output.mjs
@@ -1,0 +1,12 @@
+/*#__CJS__*/ const _ns = _interopImportCJSNamespaceT(_nsOrig);
+function _interopImportCJSNamespaceT(ns) {
+    return ns.default && ns.default.__esModule ? ns : {
+        ...ns,
+        default: ns
+    };
+}
+import * as _nsOrig from "mod";
+v = 42;
+[v] = [
+    42
+];

--- a/packages/swc-plugin-node-cjs-interop/tests/index.rs
+++ b/packages/swc-plugin-node-cjs-interop/tests/index.rs
@@ -17,6 +17,7 @@ fn test_basic(input: PathBuf) {
                 t.comments.clone(),
                 TransformOptions {
                     packages: vec!["mod".to_owned(), "mod1".to_owned(), "mod2".to_owned()],
+                    packages_t: vec![],
                     loose: false,
                     use_runtime: false,
                 },
@@ -38,7 +39,30 @@ fn test_loose(input: PathBuf) {
                 t.comments.clone(),
                 TransformOptions {
                     packages: vec!["mod".to_owned(), "mod1".to_owned(), "mod2".to_owned()],
+                    packages_t: vec![],
                     loose: true,
+                    use_runtime: false,
+                },
+            ))
+        },
+        &input,
+        &output,
+        FixtureTestConfig::default(),
+    );
+}
+
+#[testing::fixture("tests/fixtures/ts-twisted/*/input.mjs")]
+fn test_ts_twisted(input: PathBuf) {
+    let output = input.with_file_name("output.mjs");
+    test_fixture(
+        Syntax::Es(EsConfig::default()),
+        &|t| {
+            as_folder(TransformVisitor::new(
+                t.comments.clone(),
+                TransformOptions {
+                    packages: vec![],
+                    packages_t: vec!["mod".to_owned(), "mod1".to_owned(), "mod2".to_owned()],
+                    loose: false,
                     use_runtime: false,
                 },
             ))
@@ -64,6 +88,7 @@ fn test_package_filtering(input: PathBuf) {
                         "@scoped/foo".to_owned(),
                         "@scoped/bar".to_owned(),
                     ],
+                    packages_t: vec![],
                     loose: false,
                     use_runtime: false,
                 },
@@ -85,6 +110,7 @@ fn test_use_runtime(input: PathBuf) {
                 t.comments.clone(),
                 TransformOptions {
                     packages: vec!["mod".to_owned(), "mod1".to_owned(), "mod2".to_owned()],
+                    packages_t: vec![],
                     loose: false,
                     use_runtime: true,
                 },
@@ -109,6 +135,7 @@ fn test_with_react(input: PathBuf) {
                 t.comments.clone(),
                 TransformOptions {
                     packages: vec!["mod".to_owned(), "mod2".to_owned()],
+                    packages_t: vec![],
                     loose: false,
                     use_runtime: false,
                 },
@@ -131,6 +158,7 @@ fn test_with_typescript(input: PathBuf) {
                     t.comments.clone(),
                     TransformOptions {
                         packages: vec!["mod".to_owned()],
+                        packages_t: vec![],
                         loose: false,
                         use_runtime: false,
                     },


### PR DESCRIPTION
Useful in certain situations where you need to align with TypeScript's bizarre behavior around `.cts` mode.